### PR TITLE
feat: add saveNormalChunks config to skip saving LOD-only chunks

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,6 +19,7 @@ cloth_config_version=15.0.127
 mod_menu_version=11.0.1
 
 # Gradle
+org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-21.0.9.10-hotspot
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,6 @@ cloth_config_version=15.0.127
 mod_menu_version=11.0.1
 
 # Gradle
-org.gradle.java.home=C:\\Program Files\\Eclipse Adoptium\\jdk-21.0.9.10-hotspot
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 

--- a/src/main/java/com/ethan/voxyworldgenv2/VoxyWorldGenV2.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/VoxyWorldGenV2.java
@@ -18,6 +18,15 @@ public class VoxyWorldGenV2 implements ModInitializer {
     public void onInitialize() {
         LOGGER.info("voxy world gen v2 initializing");
         com.ethan.voxyworldgenv2.core.Config.load();
+
+        if (!com.ethan.voxyworldgenv2.core.Config.DATA.saveNormalChunks) {
+            LOGGER.warn("========================================");
+            LOGGER.warn("saveNormalChunks is DISABLED");
+            LOGGER.warn("Only LOD-only chunks will skip saving");
+            LOGGER.warn("Player-visited chunks WILL be saved");
+            LOGGER.warn("========================================");
+        }
+
         NetworkHandler.init();
         
         // server lifecycle events

--- a/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
@@ -65,7 +65,8 @@ public final class DebugRenderer {
             lineList.add("§7completed: §a" + formatNumber(stats.getCompleted()));
             lineList.add("§7skipped: §f" + formatNumber(stats.getSkipped()));
             if (!com.ethan.voxyworldgenv2.core.Config.DATA.saveNormalChunks) {
-                lineList.add("§7saves skipped: §c" + formatNumber(stats.getSaveSkipped()));
+                long skipped = com.ethan.voxyworldgenv2.core.LodChunkTracker.getInstance().getSkippedSaveCount();
+                lineList.add("§7saves skipped: §c" + formatNumber(skipped));
             }
             lineList.add("§7remaining: §e" + formatNumber(remaining) + " §8(" + eta + ")");
             lineList.add("§7active: §b" + manager.getActiveTaskCount());

--- a/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
@@ -64,6 +64,9 @@ public final class DebugRenderer {
             lineList.add("§6[voxy worldgen v2] " + status);
             lineList.add("§7completed: §a" + formatNumber(stats.getCompleted()));
             lineList.add("§7skipped: §f" + formatNumber(stats.getSkipped()));
+            if (!com.ethan.voxyworldgenv2.core.Config.DATA.saveNormalChunks) {
+                lineList.add("§7saves skipped: §c" + formatNumber(stats.getSaveSkipped()));
+            }
             lineList.add("§7remaining: §e" + formatNumber(remaining) + " §8(" + eta + ")");
             lineList.add("§7active: §b" + manager.getActiveTaskCount());
             lineList.add("§7rate: §f" + String.format("%.1f", rate) + " c/s");

--- a/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
@@ -66,7 +66,7 @@ public final class DebugRenderer {
             lineList.add("§7skipped: §f" + formatNumber(stats.getSkipped()));
             if (!com.ethan.voxyworldgenv2.core.Config.DATA.saveNormalChunks) {
                 long skipped = com.ethan.voxyworldgenv2.core.LodChunkTracker.getInstance().getSkippedSaveCount();
-                lineList.add("§7saves skipped: §c" + formatNumber(skipped));
+                lineList.add("§7lod suppressed: §6" + formatNumber(skipped));
             }
             lineList.add("§7remaining: §e" + formatNumber(remaining) + " §8(" + eta + ")");
             lineList.add("§7active: §b" + manager.getActiveTaskCount());

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -321,7 +321,10 @@ public final class ChunkGenerationManager {
                                             onSuccess(finalState, pos);
                                             if (!chunk.isEmpty()) {
                                                 if (!Config.DATA.saveNormalChunks) {
-                                                    LodChunkTracker.getInstance().markLod(finalState.level.dimension(), pos.toLong());
+                                                    LodChunkTracker tracker = LodChunkTracker.getInstance();
+                                                    tracker.markLod(finalState.level.dimension(), pos.toLong());
+                                                    ((com.ethan.voxyworldgenv2.mixin.ChunkAccessUnsavedMixin) chunk).voxyworldgen$setUnsaved(false);
+                                                    tracker.incrementSkipped();
                                                 }
                                                 VoxyIntegration.ingestChunk(chunk);
                                                 com.ethan.voxyworldgenv2.network.NetworkHandler.broadcastLODData(chunk);
@@ -578,5 +581,26 @@ public final class ChunkGenerationManager {
     
     public void setPauseCheck(java.util.function.BooleanSupplier check) {
         this.pauseCheck = check;
+    }
+
+    /**
+     * Thread-safe player proximity check using the ConcurrentHashMaps
+     * updated each tick. Safe to call from C2ME storage threads.
+     */
+    public boolean isAnyPlayerNear(ResourceKey<Level> dim, ChunkPos pos) {
+        var srv = this.server;
+        int viewDist = srv != null
+            ? srv.getPlayerList().getViewDistance() + 2
+            : 10;
+        for (var entry : lastPlayerPositions.entrySet()) {
+            ResourceKey<Level> playerDim = lastPlayerDimensions.get(entry.getKey());
+            if (!dim.equals(playerDim)) continue;
+            ChunkPos playerPos = entry.getValue();
+            if (Math.abs(playerPos.x - pos.x) <= viewDist
+                    && Math.abs(playerPos.z - pos.z) <= viewDist) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -3,6 +3,7 @@ package com.ethan.voxyworldgenv2.core;
 import com.ethan.voxyworldgenv2.VoxyWorldGenV2;
 import com.ethan.voxyworldgenv2.integration.VoxyIntegration;
 import com.ethan.voxyworldgenv2.integration.tellus.TellusIntegration;
+import com.ethan.voxyworldgenv2.core.LodChunkTracker;
 import com.ethan.voxyworldgenv2.mixin.MinecraftServerAccess;
 
 import com.ethan.voxyworldgenv2.mixin.ServerChunkCacheMixin;
@@ -46,7 +47,6 @@ public final class ChunkGenerationManager {
         final DistanceGraph distanceGraph = new DistanceGraph();
         final Set<Long> trackedBatches = ConcurrentHashMap.newKeySet();
         final Map<Long, AtomicInteger> batchCounters = new ConcurrentHashMap<>();
-        final LongSet playerClaimedChunks = LongSets.synchronize(new LongOpenHashSet());
         final AtomicInteger remainingInRadius = new AtomicInteger(0);
         boolean tellusActive = false;
         boolean loaded = false;
@@ -115,13 +115,13 @@ public final class ChunkGenerationManager {
         running.set(false);
         stopWorker();
         TellusIntegration.shutdown();
+        LodChunkTracker.getInstance().clearAll();
         
         for (var entry : dimensionStates.entrySet()) {
             DimensionState state = entry.getValue();
             if (state.loaded) {
                 ChunkPersistence.save(state.level, entry.getKey(), state.completedChunks);
             }
-            state.playerClaimedChunks.clear();
         }
         
         dimensionStates.clear();
@@ -320,6 +320,9 @@ public final class ChunkGenerationManager {
                                         if (throwable == null && result != null && result.isSuccess() && result.orElse(null) instanceof LevelChunk chunk) {
                                             onSuccess(finalState, pos);
                                             if (!chunk.isEmpty()) {
+                                                if (!Config.DATA.saveNormalChunks) {
+                                                    LodChunkTracker.getInstance().markLod(finalState.level.dimension(), pos.toLong());
+                                                }
                                                 VoxyIntegration.ingestChunk(chunk);
                                                 com.ethan.voxyworldgenv2.network.NetworkHandler.broadcastLODData(chunk);
                                             }
@@ -349,16 +352,8 @@ public final class ChunkGenerationManager {
         processPendingTickets();
         
         if (configReloadScheduled.compareAndSet(true, false)) {
-            boolean wasSaveNormal = Config.DATA.saveNormalChunks;
             Config.load();
             updateThrottleCapacity();
-            
-            if (wasSaveNormal && !Config.DATA.saveNormalChunks) {
-                for (ServerPlayer player : PlayerTracker.getInstance().getPlayers()) {
-                    claimPlayerViewDistance(player);
-                }
-            }
-            
             restartScan();
         }
         
@@ -402,7 +397,6 @@ public final class ChunkGenerationManager {
             if (chunkChanged || dimensionChanged) {
                 lastPlayerPositions.put(playerId, currentPos);
                 lastPlayerDimensions.put(playerId, currentDim);
-                claimPlayerViewDistance(player);
             }
             if (lastPos == null || dimensionChanged || distSq(lastPos, currentPos) >= 4) {
                 shouldRescan = true;
@@ -445,20 +439,7 @@ public final class ChunkGenerationManager {
         return (double) dx * dx + dz * dz;
     }
 
-    private void claimPlayerViewDistance(ServerPlayer player) {
-        if (Config.DATA.saveNormalChunks) return;
-
-        DimensionState state = getOrSetupState((ServerLevel) player.level());
-
-        int viewDist = server.getPlayerList().getViewDistance();
-        ChunkPos playerChunk = player.chunkPosition();
-
-        for (int dx = -viewDist; dx <= viewDist; dx++) {
-            for (int dz = -viewDist; dz <= viewDist; dz++) {
-                state.playerClaimedChunks.add(ChunkPos.asLong(playerChunk.x + dx, playerChunk.z + dz));
-            }
-        }
-    }
+    
 
     private void setupLevel(ServerLevel newLevel) {
         if (currentLevel != null && currentDimensionKey != null) {
@@ -593,15 +574,7 @@ public final class ChunkGenerationManager {
     public boolean isThrottled() { return tpsMonitor.isThrottled(); }
     public int getQueueSize() { return 0; }
 
-    public boolean isVoxyOnlyChunk(ResourceKey<Level> dimension, long chunkPos) {
-        DimensionState state = dimensionStates.get(dimension);
-        if (state == null) return false;
-        return state.completedChunks.contains(chunkPos) && !state.playerClaimedChunks.contains(chunkPos);
-    }
 
-    public void incrementSaveSkipped() {
-        stats.incrementSaveSkipped();
-    }
     
     public void setPauseCheck(java.util.function.BooleanSupplier check) {
         this.pauseCheck = check;

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -71,6 +71,7 @@ public final class ChunkGenerationManager {
     private ResourceKey<Level> currentDimensionKey = null;
     private ServerLevel currentLevel = null;
     private final java.util.Map<java.util.UUID, ChunkPos> lastPlayerPositions = new java.util.concurrent.ConcurrentHashMap<>();
+    private final java.util.Map<java.util.UUID, ResourceKey<Level>> lastPlayerDimensions = new java.util.concurrent.ConcurrentHashMap<>();
     private java.util.function.BooleanSupplier pauseCheck = () -> false;
 
     // worker
@@ -380,12 +381,20 @@ public final class ChunkGenerationManager {
         
         for (ServerPlayer player : players) {
             levelCounts.merge((ServerLevel) player.level(), 1, Integer::sum);
+            java.util.UUID playerId = player.getUUID();
             ChunkPos currentPos = player.chunkPosition();
-            ChunkPos lastPos = lastPlayerPositions.get(player.getUUID());
-            
-            if (lastPos == null || distSq(lastPos, currentPos) >= 4) {
-                lastPlayerPositions.put(player.getUUID(), currentPos);
+            ChunkPos lastPos = lastPlayerPositions.get(playerId);
+            ResourceKey<Level> currentDim = player.level().dimension();
+            ResourceKey<Level> lastDim = lastPlayerDimensions.get(playerId);
+            boolean dimensionChanged = lastDim != null && !lastDim.equals(currentDim);
+            boolean chunkChanged = lastPos == null || !lastPos.equals(currentPos);
+
+            if (chunkChanged || dimensionChanged) {
+                lastPlayerPositions.put(playerId, currentPos);
+                lastPlayerDimensions.put(playerId, currentDim);
                 claimPlayerViewDistance(player);
+            }
+            if (lastPos == null || dimensionChanged || distSq(lastPos, currentPos) >= 4) {
                 shouldRescan = true;
             }
         }
@@ -411,6 +420,7 @@ public final class ChunkGenerationManager {
         for (ServerPlayer p : players) currentPlayerIds.add(p.getUUID());
         if (lastPlayerPositions.size() > currentPlayerIds.size()) {
             lastPlayerPositions.keySet().removeIf(uuid -> !currentPlayerIds.contains(uuid));
+            lastPlayerDimensions.keySet().removeIf(uuid -> !currentPlayerIds.contains(uuid));
             shouldRescan = true;
         }
 
@@ -428,8 +438,7 @@ public final class ChunkGenerationManager {
     private void claimPlayerViewDistance(ServerPlayer player) {
         if (Config.DATA.saveNormalChunks) return;
 
-        DimensionState state = dimensionStates.get(player.level().dimension());
-        if (state == null) return;
+        DimensionState state = getOrSetupState((ServerLevel) player.level());
 
         int viewDist = server.getPlayerList().getViewDistance();
         ChunkPos playerChunk = player.chunkPosition();

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -133,6 +133,7 @@ public final class ChunkGenerationManager {
         currentDimensionKey = null;
         currentLevel = null;
         lastPlayerPositions.clear();
+        lastPlayerDimensions.clear();
     }
 
     private void startWorker() {
@@ -348,8 +349,16 @@ public final class ChunkGenerationManager {
         processPendingTickets();
         
         if (configReloadScheduled.compareAndSet(true, false)) {
+            boolean wasSaveNormal = Config.DATA.saveNormalChunks;
             Config.load();
             updateThrottleCapacity();
+            
+            if (wasSaveNormal && !Config.DATA.saveNormalChunks) {
+                for (ServerPlayer player : PlayerTracker.getInstance().getPlayers()) {
+                    claimPlayerViewDistance(player);
+                }
+            }
+            
             restartScan();
         }
         
@@ -372,6 +381,7 @@ public final class ChunkGenerationManager {
         if (players.isEmpty()) {
             if (!lastPlayerPositions.isEmpty()) {
                 lastPlayerPositions.clear();
+                lastPlayerDimensions.clear();
             }
             return;
         }

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -59,10 +59,16 @@ public final class ChunkGenerationManager {
     private final Map<ResourceKey<Level>, DimensionState> dimensionStates = new ConcurrentHashMap<>();
     
     // global state
+    // Tracks how many server.execute() generation batches are in-flight.
+    // Used to prevent flooding the server executor queue.
+    private final AtomicInteger pendingServerBatches = new AtomicInteger(0);
+    private final AtomicInteger pendingSyncBatches = new AtomicInteger(0);
     private final AtomicInteger activeTaskCount = new AtomicInteger(0);
     private final GenerationStats stats = new GenerationStats();
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicBoolean configReloadScheduled = new AtomicBoolean(false);
+    private int saveTickCounter = 0;
+    private static final int SAVE_INTERVAL_TICKS = 1200;
     
     // components
     private final TpsMonitor tpsMonitor = new TpsMonitor();
@@ -72,6 +78,7 @@ public final class ChunkGenerationManager {
     private ServerLevel currentLevel = null;
     private final java.util.Map<java.util.UUID, ChunkPos> lastPlayerPositions = new java.util.concurrent.ConcurrentHashMap<>();
     private final java.util.Map<java.util.UUID, ResourceKey<Level>> lastPlayerDimensions = new java.util.concurrent.ConcurrentHashMap<>();
+    private final java.util.Map<java.util.UUID, ChunkPos> lastScanPositions = new java.util.concurrent.ConcurrentHashMap<>();
     private java.util.function.BooleanSupplier pauseCheck = () -> false;
 
     // worker
@@ -103,37 +110,63 @@ public final class ChunkGenerationManager {
     public void initialize(MinecraftServer server) {
         this.server = server;
         this.running.set(true);
-        // unpaused by default
-        this.pauseCheck = () -> false; 
+        this.pauseCheck = () -> false;
+        // Reset LOD tracker for this session. Must be here (not in shutdown) so
+        // the tracker stays alive through the previous session's async chunk unload.
+        LodChunkTracker.getInstance().clearAll();
         Config.load();
         this.throttle = new Semaphore(Config.DATA.maxActiveTasks);
+        pendingServerBatches.set(0);
+        pendingSyncBatches.set(0);
+        saveTickCounter = 0;
         startWorker();
         VoxyWorldGenV2.LOGGER.info("voxy world gen initialized");
     }
     
     public void shutdown() {
         running.set(false);
-        stopWorker();
+        stopWorker();  // joins worker thread, no more dispatches after this
         TellusIntegration.shutdown();
-        LodChunkTracker.getInstance().clearAll();
-        
+
+        // Force-queue ticket removes for every chunk still being tracked.
+        // The worker is already stopped so trackedChunks won't change concurrently.
+        for (DimensionState state : dimensionStates.values()) {
+            // Snapshot to a plain array to avoid iterator issues on the synchronized set.
+            long[] tracked = state.trackedChunks.toLongArray();
+            for (long packed : tracked) {
+                queueTicketRemove(state.level, new ChunkPos(packed));
+            }
+        }
+        // Drain ALL pending ticket ops (both adds queued during generation AND the
+        // removes we just enqueued). This calls removeTicketWithRadius + distance
+        // manager update so those chunks become eligible to unload normally.
+        // Must run before we clear dimensionStates so level references are valid.
+        processPendingTickets();
+
+        // Save binary caches for all dimensions that were set up this session.
         for (var entry : dimensionStates.entrySet()) {
             DimensionState state = entry.getValue();
             if (state.loaded) {
                 ChunkPersistence.save(state.level, entry.getKey(), state.completedChunks);
             }
         }
-        
+
         dimensionStates.clear();
-        pendingTicketOps.clear();
+        pendingTicketOps.clear();  // should already be empty; clear for safety
         server = null;
         stats.reset();
         activeTaskCount.set(0);
+        pendingServerBatches.set(0);
         tpsMonitor.reset();
         currentDimensionKey = null;
         currentLevel = null;
         lastPlayerPositions.clear();
         lastPlayerDimensions.clear();
+        lastScanPositions.clear();
+        // NOTE: LodChunkTracker.clearAll() is intentionally NOT called here.
+        // The tracker must remain populated so ChunkSaveMixin can suppress saves
+        // for LOD-only chunks during the async unload phase that follows shutdown.
+        // clearAll() is called at the start of initialize() for the next session.
     }
 
     private void startWorker() {
@@ -166,7 +199,14 @@ public final class ChunkGenerationManager {
                 }
 
                 if (tpsMonitor.isThrottled() || pauseCheck.getAsBoolean()) {
-                    Thread.sleep(500);
+                    // Wait for existing in-flight tasks to complete before dispatching more,
+                    // so we don't keep adding to an already-overloaded server executor queue.
+                    int waited = 0;
+                    while ((tpsMonitor.isThrottled() || activeTaskCount.get() > 0)
+                            && workerRunning.get() && waited < 60) {
+                        Thread.sleep(500);
+                        waited++;
+                    }
                     continue;
                 }
                 
@@ -193,32 +233,42 @@ public final class ChunkGenerationManager {
                 if (batch == null) {
                     // if no generation work, try to catch up on syncing for any player
                     boolean workDispatched = false;
-                    for (ServerPlayer player : players) {
-                        var synced = PlayerTracker.getInstance().getSyncedChunks(player.getUUID());
-                        if (synced == null) continue;
-                        
-                        DimensionState ds = getOrSetupState((ServerLevel) player.level());
-                        int radius = ds.tellusActive ? Math.max(Config.DATA.generationRadius, 128) : Config.DATA.generationRadius;
-                        List<ChunkPos> syncBatch = new ArrayList<>();
-                        ds.distanceGraph.collectCompletedInRange(player.chunkPosition(), radius, synced, syncBatch, 64);
-                        
-                        if (!syncBatch.isEmpty()) {
-                            workDispatched = true;
-                            final List<ChunkPos> finalSyncBatch = new ArrayList<>(syncBatch);
-                            final ServerLevel level = ds.level;
-                            final UUID playerUUID = player.getUUID();
-                            server.execute(() -> {
-                                ServerPlayer p = server.getPlayerList().getPlayer(playerUUID);
-                                if (p != null) {
-                                    for (ChunkPos syncPos : finalSyncBatch) {
-                                        LevelChunk c = level.getChunkSource().getChunk(syncPos.x, syncPos.z, false);
-                                        if (c != null) {
-                                            com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(p, c);
+                    if (pendingSyncBatches.get() < 2) {
+                        for (ServerPlayer player : players) {
+                            var synced = PlayerTracker.getInstance().getSyncedChunks(player.getUUID());
+                            if (synced == null) continue;
+                            
+                            DimensionState ds = getOrSetupState((ServerLevel) player.level());
+                            int radius = ds.tellusActive ? Math.max(Config.DATA.generationRadius, 128) : Config.DATA.generationRadius;
+                            List<ChunkPos> syncBatch = new ArrayList<>();
+                            ds.distanceGraph.collectCompletedInRange(player.chunkPosition(), radius, synced, syncBatch, 64);
+                            
+                            if (!syncBatch.isEmpty()) {
+                                workDispatched = true;
+                                final List<ChunkPos> finalSyncBatch = new ArrayList<>(syncBatch);
+                                final ServerLevel level = ds.level;
+                                final UUID playerUUID = player.getUUID();
+                                final MinecraftServer syncSrv = server;
+                                if (syncSrv == null) break;
+                                
+                                pendingSyncBatches.incrementAndGet();
+                                syncSrv.execute(() -> {
+                                    try {
+                                        ServerPlayer p = syncSrv.getPlayerList().getPlayer(playerUUID);
+                                        if (p != null) {
+                                            for (ChunkPos syncPos : finalSyncBatch) {
+                                                LevelChunk c = level.getChunkSource().getChunk(syncPos.x, syncPos.z, false);
+                                                if (c != null) {
+                                                    com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(p, c);
+                                                }
+                                            }
                                         }
+                                    } finally {
+                                        pendingSyncBatches.decrementAndGet();
                                     }
-                                }
-                            });
-                            break; // processed one player, break to skip sleep
+                                });
+                                break; // processed one player, break to skip sleep
+                            }
                         }
                     }
                     
@@ -291,50 +341,78 @@ public final class ChunkGenerationManager {
                 }
 
                 if (!readyToGenerate.isEmpty()) {
-                    server.execute(() -> {
-                        ServerChunkCache cache = finalState.level.getChunkSource();
-                        List<ChunkPos> actuallyGenerate = new ArrayList<>();
-                        
+                    final MinecraftServer srv = server;
+                    if (srv == null) {
                         for (ChunkPos pos : readyToGenerate) {
-                            if (finalState.level.hasChunk(pos.x, pos.z)) {
-                                LevelChunk existingChunk = finalState.level.getChunk(pos.x, pos.z);
-                                if (existingChunk != null && !existingChunk.isEmpty()) {
-                                    VoxyIntegration.ingestChunk(existingChunk);
-                                    com.ethan.voxyworldgenv2.network.NetworkHandler.broadcastLODData(existingChunk);
-                                }
-                                onSuccess(finalState, pos);
-                                completeTask(finalState, pos);
-                            } else {
-                                queueTicketAdd(finalState.level, pos);
-                                actuallyGenerate.add(pos);
-                            }
+                            onFailure(finalState, pos);
+                            completeTask(finalState, pos);
                         }
-                        
-                        if (!actuallyGenerate.isEmpty()) {
-                            // apply tickets immediately to ensure DistanceManager is aware of them, keeps stuff nice and clean
-                            processPendingTickets();
+                        finalState.trackedBatches.remove(batchKey);
+                        finalState.batchCounters.remove(batchKey);
+                        continue;
+                    }
 
-                            for (ChunkPos pos : actuallyGenerate) {
-                                ((ServerChunkCacheMixin) cache).invokeGetChunkFutureMainThread(pos.x, pos.z, ChunkStatus.FULL, true)
-                                    .whenCompleteAsync((result, throwable) -> {
-                                        if (throwable == null && result != null && result.isSuccess() && result.orElse(null) instanceof LevelChunk chunk) {
-                                            onSuccess(finalState, pos);
-                                            if (!chunk.isEmpty()) {
-                                                if (!Config.DATA.saveNormalChunks) {
-                                                    LodChunkTracker tracker = LodChunkTracker.getInstance();
-                                                    tracker.markLod(finalState.level.dimension(), pos.toLong());
-                                                    ((com.ethan.voxyworldgenv2.mixin.ChunkAccessUnsavedMixin) chunk).voxyworldgen$setUnsaved(false);
-                                                    tracker.incrementSkipped();
-                                                }
-                                                VoxyIntegration.ingestChunk(chunk);
-                                                com.ethan.voxyworldgenv2.network.NetworkHandler.broadcastLODData(chunk);
-                                            }
-                                        } else {
-                                            onFailure(finalState, pos);
-                                        }
-                                        cleanupTask(finalState.level, pos);
-                                    }, server);
+                    // Backpressure: don't let the server executor queue grow unbounded.
+                    int waited = 0;
+                    while (pendingServerBatches.get() > Config.DATA.maxActiveTasks
+                            && workerRunning.get() && waited < 20) {
+                        try { Thread.sleep(50); } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt(); break;
+                        }
+                        waited++;
+                    }
+
+                    pendingServerBatches.incrementAndGet();
+                    srv.execute(() -> {
+                        try {
+                            ServerChunkCache cache = finalState.level.getChunkSource();
+                            List<ChunkPos> actuallyGenerate = new ArrayList<>();
+                            
+                            for (ChunkPos pos : readyToGenerate) {
+                                if (finalState.level.hasChunk(pos.x, pos.z)) {
+                                    LevelChunk existingChunk = finalState.level.getChunk(pos.x, pos.z);
+                                    if (existingChunk != null && !existingChunk.isEmpty()) {
+                                        VoxyIntegration.ingestChunk(existingChunk);
+                                        com.ethan.voxyworldgenv2.network.NetworkHandler.broadcastLODData(existingChunk);
+                                    }
+                                    onSuccess(finalState, pos);
+                                    completeTask(finalState, pos);
+                                } else {
+                                    queueTicketAdd(finalState.level, pos);
+                                    actuallyGenerate.add(pos);
+                                }
                             }
+                            
+                            if (!actuallyGenerate.isEmpty()) {
+                                processPendingTickets();
+
+                                for (ChunkPos pos : actuallyGenerate) {
+                                    ((ServerChunkCacheMixin) cache).invokeGetChunkFutureMainThread(pos.x, pos.z, ChunkStatus.FULL, true)
+                                        .whenCompleteAsync((result, throwable) -> {
+                                            try {
+                                                if (throwable == null && result != null && result.isSuccess() && result.orElse(null) instanceof LevelChunk chunk) {
+                                                    if (!chunk.isEmpty()) {
+                                                        if (!Config.DATA.saveNormalChunks) {
+                                                            LodChunkTracker tracker = LodChunkTracker.getInstance();
+                                                            tracker.markLod(finalState.level.dimension(), pos.toLong());
+                                                            ((com.ethan.voxyworldgenv2.mixin.ChunkAccessUnsavedMixin) chunk).voxyworldgen$setUnsaved(false);
+                                                            tracker.incrementSkipped();
+                                                        }
+                                                        VoxyIntegration.ingestChunk(chunk);
+                                                        com.ethan.voxyworldgenv2.network.NetworkHandler.broadcastLODData(chunk);
+                                                    }
+                                                    onSuccess(finalState, pos);
+                                                } else {
+                                                    onFailure(finalState, pos);
+                                                }
+                                            } finally {
+                                                cleanupTask(finalState.level, pos);
+                                            }
+                                        }, srv);
+                                }
+                            }
+                        } finally {
+                            pendingServerBatches.decrementAndGet();
                         }
                     });
                 }
@@ -364,6 +442,18 @@ public final class ChunkGenerationManager {
         stats.tick();
         checkPlayerMovement();
         
+        // periodic save of completed chunks to survive crashes
+        saveTickCounter++;
+        if (saveTickCounter >= SAVE_INTERVAL_TICKS) {
+            saveTickCounter = 0;
+            for (var entry : dimensionStates.entrySet()) {
+                DimensionState state = entry.getValue();
+                if (state.loaded) {
+                    ChunkPersistence.save(state.level, entry.getKey(), state.completedChunks);
+                }
+            }
+        }
+        
         // broadcast changes for all active dimensions
         Set<ServerLevel> activeLevels = new HashSet<>();
         for (ServerPlayer player : PlayerTracker.getInstance().getPlayers()) {
@@ -380,6 +470,7 @@ public final class ChunkGenerationManager {
             if (!lastPlayerPositions.isEmpty()) {
                 lastPlayerPositions.clear();
                 lastPlayerDimensions.clear();
+                lastScanPositions.clear();
             }
             return;
         }
@@ -391,17 +482,16 @@ public final class ChunkGenerationManager {
             levelCounts.merge((ServerLevel) player.level(), 1, Integer::sum);
             java.util.UUID playerId = player.getUUID();
             ChunkPos currentPos = player.chunkPosition();
-            ChunkPos lastPos = lastPlayerPositions.get(playerId);
             ResourceKey<Level> currentDim = player.level().dimension();
             ResourceKey<Level> lastDim = lastPlayerDimensions.get(playerId);
             boolean dimensionChanged = lastDim != null && !lastDim.equals(currentDim);
-            boolean chunkChanged = lastPos == null || !lastPos.equals(currentPos);
 
-            if (chunkChanged || dimensionChanged) {
-                lastPlayerPositions.put(playerId, currentPos);
-                lastPlayerDimensions.put(playerId, currentDim);
-            }
-            if (lastPos == null || dimensionChanged || distSq(lastPos, currentPos) >= 4) {
+            lastPlayerPositions.put(playerId, currentPos);
+            lastPlayerDimensions.put(playerId, currentDim);
+
+            ChunkPos lastScanPos = lastScanPositions.get(playerId);
+            if (lastScanPos == null || dimensionChanged || distSq(lastScanPos, currentPos) >= 4) {
+                lastScanPositions.put(playerId, currentPos);
                 shouldRescan = true;
             }
         }
@@ -428,6 +518,7 @@ public final class ChunkGenerationManager {
         if (lastPlayerPositions.size() > currentPlayerIds.size()) {
             lastPlayerPositions.keySet().removeIf(uuid -> !currentPlayerIds.contains(uuid));
             lastPlayerDimensions.keySet().removeIf(uuid -> !currentPlayerIds.contains(uuid));
+            lastScanPositions.keySet().removeIf(uuid -> !currentPlayerIds.contains(uuid));
             shouldRescan = true;
         }
 
@@ -484,7 +575,9 @@ public final class ChunkGenerationManager {
             maxCounts.merge(state, missing, Math::max);
         }
         
-        maxCounts.forEach((state, count) -> state.remainingInRadius.set(count));
+        maxCounts.forEach((state, count) -> {
+            state.remainingInRadius.set(Math.max(0, count));
+        });
     }
 
     private void updateThrottleCapacity() {
@@ -523,7 +616,10 @@ public final class ChunkGenerationManager {
     
     private void cleanupTask(ServerLevel level, ChunkPos pos) {
         queueTicketRemove(level, pos);
-        ((MinecraftServerAccess) server).setEmptyTicks(0);
+        MinecraftServer srv = server;
+        if (srv != null) {
+            ((MinecraftServerAccess) srv).setEmptyTicks(0);
+        }
         DimensionState state = dimensionStates.get(level.dimension());
         if (state != null) completeTask(state, pos);
     }
@@ -533,7 +629,7 @@ public final class ChunkGenerationManager {
         if (state.completedChunks.add(key)) {
             stats.incrementCompleted();
             state.distanceGraph.markChunkCompleted(pos.x, pos.z);
-            state.remainingInRadius.decrementAndGet();
+            state.remainingInRadius.updateAndGet(v -> Math.max(0, v - 1));
         } else {
             stats.incrementSkipped();
             state.distanceGraph.markChunkCompleted(pos.x, pos.z);

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -46,6 +46,7 @@ public final class ChunkGenerationManager {
         final DistanceGraph distanceGraph = new DistanceGraph();
         final Set<Long> trackedBatches = ConcurrentHashMap.newKeySet();
         final Map<Long, AtomicInteger> batchCounters = new ConcurrentHashMap<>();
+        final LongSet playerClaimedChunks = LongSets.synchronize(new LongOpenHashSet());
         final AtomicInteger remainingInRadius = new AtomicInteger(0);
         boolean tellusActive = false;
         boolean loaded = false;
@@ -119,6 +120,7 @@ public final class ChunkGenerationManager {
             if (state.loaded) {
                 ChunkPersistence.save(state.level, entry.getKey(), state.completedChunks);
             }
+            state.playerClaimedChunks.clear();
         }
         
         dimensionStates.clear();
@@ -383,6 +385,7 @@ public final class ChunkGenerationManager {
             
             if (lastPos == null || distSq(lastPos, currentPos) >= 4) {
                 lastPlayerPositions.put(player.getUUID(), currentPos);
+                claimPlayerViewDistance(player);
                 shouldRescan = true;
             }
         }
@@ -420,6 +423,22 @@ public final class ChunkGenerationManager {
         int dx = a.x - b.x;
         int dz = a.z - b.z;
         return (double) dx * dx + dz * dz;
+    }
+
+    private void claimPlayerViewDistance(ServerPlayer player) {
+        if (Config.DATA.saveNormalChunks) return;
+
+        DimensionState state = dimensionStates.get(player.level().dimension());
+        if (state == null) return;
+
+        int viewDist = server.getPlayerList().getViewDistance();
+        ChunkPos playerChunk = player.chunkPosition();
+
+        for (int dx = -viewDist; dx <= viewDist; dx++) {
+            for (int dz = -viewDist; dz <= viewDist; dz++) {
+                state.playerClaimedChunks.add(ChunkPos.asLong(playerChunk.x + dx, playerChunk.z + dz));
+            }
+        }
     }
 
     private void setupLevel(ServerLevel newLevel) {
@@ -554,6 +573,16 @@ public final class ChunkGenerationManager {
     }
     public boolean isThrottled() { return tpsMonitor.isThrottled(); }
     public int getQueueSize() { return 0; }
+
+    public boolean isVoxyOnlyChunk(ResourceKey<Level> dimension, long chunkPos) {
+        DimensionState state = dimensionStates.get(dimension);
+        if (state == null) return false;
+        return state.completedChunks.contains(chunkPos) && !state.playerClaimedChunks.contains(chunkPos);
+    }
+
+    public void incrementSaveSkipped() {
+        stats.incrementSaveSkipped();
+    }
     
     public void setPauseCheck(java.util.function.BooleanSupplier check) {
         this.pauseCheck = check;

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkPersistence.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkPersistence.java
@@ -1,6 +1,7 @@
 package com.ethan.voxyworldgenv2.core;
 
 import com.ethan.voxyworldgenv2.VoxyWorldGenV2;
+import com.ethan.voxyworldgenv2.integration.VoxyIntegration;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.Level;
@@ -12,41 +13,69 @@ import java.nio.file.Path;
 import java.util.Set;
 
 public class ChunkPersistence {
-    
+
+    private static final int FORMAT_VERSION = 2;
+
     public static void save(ServerLevel level, ResourceKey<Level> dimKey, Set<Long> completedChunks) {
         if (level == null || dimKey == null) return;
-        
         try {
             String dimId = getDimensionId(dimKey);
-            Path savePath = level.getServer().getWorldPath(LevelResource.ROOT).resolve("voxy_gen_" + dimId + ".bin");
-            try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(savePath)))) {
-                synchronized(completedChunks) {
+            Path savePath = level.getServer().getWorldPath(LevelResource.ROOT)
+                    .resolve("voxy_gen_" + dimId + ".bin");
+            try (DataOutputStream out = new DataOutputStream(
+                    new BufferedOutputStream(Files.newOutputStream(savePath)))) {
+                out.writeInt(FORMAT_VERSION);
+                out.writeBoolean(VoxyIntegration.isVoxyAvailable()); // NEW
+                synchronized (completedChunks) {
                     out.writeInt(completedChunks.size());
-                    for (Long chunkPos : completedChunks) {
-                        out.writeLong(chunkPos);
-                    }
+                    for (Long chunkPos : completedChunks) out.writeLong(chunkPos);
                 }
             }
         } catch (Exception e) {
             VoxyWorldGenV2.LOGGER.error("failed to save chunk generation cache", e);
         }
     }
-    
+
     public static void load(ServerLevel level, ResourceKey<Level> dimKey, Set<Long> completedChunks) {
         completedChunks.clear();
         if (level == null || dimKey == null) return;
-        
         try {
             String dimId = getDimensionId(dimKey);
-            Path savePath = level.getServer().getWorldPath(LevelResource.ROOT).resolve("voxy_gen_" + dimId + ".bin");
-            if (Files.exists(savePath)) {
-                try (DataInputStream in = new DataInputStream(new BufferedInputStream(Files.newInputStream(savePath)))) {
-                    int count = in.readInt();
-                    for (int i = 0; i < count; i++) {
-                        completedChunks.add(in.readLong());
-                    }
+            Path savePath = level.getServer().getWorldPath(LevelResource.ROOT)
+                    .resolve("voxy_gen_" + dimId + ".bin");
+            if (!Files.exists(savePath)) return;
+
+            try (DataInputStream in = new DataInputStream(
+                    new BufferedInputStream(Files.newInputStream(savePath)))) {
+
+                int firstInt = in.readInt();
+
+                // Legacy format (v1): first int was directly the chunk count.
+                if (firstInt != FORMAT_VERSION) {
+                    int count = firstInt; // IS the count in the old format
+                    for (int i = 0; i < count; i++) completedChunks.add(in.readLong());
+                    VoxyWorldGenV2.LOGGER.info(
+                        "loaded {} chunks from legacy cache for {}", count, dimKey);
+                    return;
                 }
-                VoxyWorldGenV2.LOGGER.info("loaded {} chunks from voxy generation cache for {}", completedChunks.size(), dimKey);
+
+                // v2 format
+                boolean voxyWasPresent = in.readBoolean();
+                boolean voxyNowAvailable = VoxyIntegration.isVoxyAvailable();
+
+                if (!voxyWasPresent && voxyNowAvailable) {
+                    // Chunks were never ingested into Voxy. Discard so they get re-generated.
+                    VoxyWorldGenV2.LOGGER.info(
+                        "discarding stale cache for {} — Voxy absent at write time, "
+                        + "present now; will re-ingest", dimKey);
+                    return;
+                }
+
+                int count = in.readInt();
+                for (int i = 0; i < count; i++) completedChunks.add(in.readLong());
+                VoxyWorldGenV2.LOGGER.info(
+                    "loaded {} chunks from cache for {} (voxyPresent: {}/{})",
+                    completedChunks.size(), dimKey, voxyWasPresent, voxyNowAvailable);
             }
         } catch (Exception e) {
             VoxyWorldGenV2.LOGGER.error("failed to load chunk generation cache", e);
@@ -55,10 +84,7 @@ public class ChunkPersistence {
 
     private static String getDimensionId(ResourceKey<Level> dimKey) {
         return dimKey.toString()
-                .replace("ResourceKey[", "")
-                .replace("]", "")
-                .replace("/", "_")
-                .replace(":", "_")
-                .trim();
+                .replace("ResourceKey[", "").replace("]", "")
+                .replace("/", "_").replace(":", "_").trim();
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
@@ -55,5 +55,6 @@ public final class Config {
         public int update_interval = 20; // legacy field for Compat
         public int maxQueueSize = 20000;
         public int maxActiveTasks = 20;
+        public boolean saveNormalChunks = true;
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/core/LodChunkTracker.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/LodChunkTracker.java
@@ -1,0 +1,60 @@
+package com.ethan.voxyworldgenv2.core;
+
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
+import it.unimi.dsi.fastutil.longs.LongSets;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.world.level.Level;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Tracks chunk positions that were loaded exclusively for LOD generation
+ * and have not been claimed by player view distance. Session-only; not persisted.
+ */
+public final class LodChunkTracker {
+    private static final LodChunkTracker INSTANCE = new LodChunkTracker();
+
+    // per-dimension set of packed ChunkPos longs that are LOD-only this session
+    private final Map<ResourceKey<Level>, LongSet> lodChunks = new ConcurrentHashMap<>();
+    private final AtomicLong savedSkipCount = new AtomicLong(0);
+
+    private LodChunkTracker() {}
+
+    public static LodChunkTracker getInstance() {
+        return INSTANCE;
+    }
+
+    /** Mark a chunk as having been generated only for LOD purposes. */
+    public void markLod(ResourceKey<Level> dim, long packedPos) {
+        lodChunks.computeIfAbsent(dim, k -> LongSets.synchronize(new LongOpenHashSet())).add(packedPos);
+    }
+
+    /** Remove a chunk from the LOD-only set (player claimed it). */
+    public void unmark(ResourceKey<Level> dim, long packedPos) {
+        LongSet set = lodChunks.get(dim);
+        if (set != null) set.remove(packedPos);
+    }
+
+    /** Returns true if the chunk is tracked as LOD-only for this dimension. */
+    public boolean isLodOnly(ResourceKey<Level> dim, long packedPos) {
+        LongSet set = lodChunks.get(dim);
+        return set != null && set.contains(packedPos);
+    }
+
+    public void incrementSkipped() {
+        savedSkipCount.incrementAndGet();
+    }
+
+    public long getSkippedSaveCount() {
+        return savedSkipCount.get();
+    }
+
+    /** Call on server shutdown to release all memory. */
+    public void clearAll() {
+        lodChunks.clear();
+        savedSkipCount.set(0);
+    }
+}

--- a/src/main/java/com/ethan/voxyworldgenv2/core/LodChunkTracker.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/LodChunkTracker.java
@@ -2,7 +2,6 @@ package com.ethan.voxyworldgenv2.core;
 
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
-import java.util.Set;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
@@ -21,8 +20,6 @@ public final class LodChunkTracker {
     // per-dimension set of packed ChunkPos longs that are LOD-only this session
     private final Map<ResourceKey<Level>, LongSet> lodChunks = new ConcurrentHashMap<>();
     private final AtomicLong savedSkipCount = new AtomicLong(0);
-    // per-dimension set to avoid double-counting if mixin fires more than once per chunk
-    private final Map<ResourceKey<Level>, Set<Long>> skippedChunks = new ConcurrentHashMap<>();
 
     private LodChunkTracker() {}
 
@@ -51,18 +48,6 @@ public final class LodChunkTracker {
         savedSkipCount.incrementAndGet();
     }
 
-    /**
-     * Increments the skip counter only the first time a given chunk position is
-     * reported — prevents inflation if ChunkMap.save fires multiple times for
-     * the same LOD chunk across autosave cycles.
-     */
-    public void incrementSkipped(ResourceKey<Level> dim, long packedPos) {
-        Set<Long> seen = skippedChunks.computeIfAbsent(dim, k -> ConcurrentHashMap.newKeySet());
-        if (seen.add(packedPos)) {
-            savedSkipCount.incrementAndGet();
-        }
-    }
-
     public long getSkippedSaveCount() {
         return savedSkipCount.get();
     }
@@ -70,7 +55,6 @@ public final class LodChunkTracker {
     /** Call on server shutdown to release all memory. */
     public void clearAll() {
         lodChunks.clear();
-        skippedChunks.clear();
         savedSkipCount.set(0);
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/core/LodChunkTracker.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/LodChunkTracker.java
@@ -2,6 +2,7 @@ package com.ethan.voxyworldgenv2.core;
 
 import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
+import java.util.Set;
 import it.unimi.dsi.fastutil.longs.LongSets;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.world.level.Level;
@@ -20,6 +21,8 @@ public final class LodChunkTracker {
     // per-dimension set of packed ChunkPos longs that are LOD-only this session
     private final Map<ResourceKey<Level>, LongSet> lodChunks = new ConcurrentHashMap<>();
     private final AtomicLong savedSkipCount = new AtomicLong(0);
+    // per-dimension set to avoid double-counting if mixin fires more than once per chunk
+    private final Map<ResourceKey<Level>, Set<Long>> skippedChunks = new ConcurrentHashMap<>();
 
     private LodChunkTracker() {}
 
@@ -48,6 +51,18 @@ public final class LodChunkTracker {
         savedSkipCount.incrementAndGet();
     }
 
+    /**
+     * Increments the skip counter only the first time a given chunk position is
+     * reported — prevents inflation if ChunkMap.save fires multiple times for
+     * the same LOD chunk across autosave cycles.
+     */
+    public void incrementSkipped(ResourceKey<Level> dim, long packedPos) {
+        Set<Long> seen = skippedChunks.computeIfAbsent(dim, k -> ConcurrentHashMap.newKeySet());
+        if (seen.add(packedPos)) {
+            savedSkipCount.incrementAndGet();
+        }
+    }
+
     public long getSkippedSaveCount() {
         return savedSkipCount.get();
     }
@@ -55,6 +70,7 @@ public final class LodChunkTracker {
     /** Call on server shutdown to release all memory. */
     public void clearAll() {
         lodChunks.clear();
+        skippedChunks.clear();
         savedSkipCount.set(0);
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/integration/ModMenuIntegration.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/integration/ModMenuIntegration.java
@@ -54,6 +54,12 @@ public class ModMenuIntegration implements ModMenuApi {
                 .setTooltip(Component.translatable("config.voxyworldgenv2.option.max_active.tooltip"))
                 .setSaveConsumer(newValue -> Config.DATA.maxActiveTasks = newValue)
                 .build());
+
+            general.addEntry(entryBuilder.startBooleanToggle(Component.translatable("config.voxyworldgenv2.option.save_normal_chunks"), Config.DATA.saveNormalChunks)
+                .setDefaultValue(true)
+                .setTooltip(Component.translatable("config.voxyworldgenv2.option.save_normal_chunks.tooltip"))
+                .setSaveConsumer(newValue -> Config.DATA.saveNormalChunks = newValue)
+                .build());
             
             builder.setSavingRunnable(() -> {
                 Config.save();

--- a/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkAccessUnsavedMixin.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkAccessUnsavedMixin.java
@@ -1,0 +1,11 @@
+package com.ethan.voxyworldgenv2.mixin;
+
+import net.minecraft.world.level.chunk.ChunkAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ChunkAccess.class)
+public interface ChunkAccessUnsavedMixin {
+    @Accessor("unsaved")
+    void voxyworldgen$setUnsaved(boolean unsaved);
+}

--- a/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
@@ -25,8 +25,9 @@ public abstract class ChunkSaveMixin {
     private void onChunkSave(ChunkAccess chunk, CallbackInfoReturnable<Boolean> cir) {
         if (!Config.DATA.saveNormalChunks) {
             long chunkPos = chunk.getPos().toLong();
-            if (ChunkGenerationManager.getInstance().isVoxyOnlyChunk(level.dimension(), chunkPos)) {
-                ChunkGenerationManager.getInstance().incrementSaveSkipped();
+            ChunkGenerationManager manager = ChunkGenerationManager.getInstance();
+            if (manager.isVoxyOnlyChunk(level.dimension(), chunkPos)) {
+                manager.incrementSaveSkipped();
                 cir.setReturnValue(true);
             }
         }

--- a/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
@@ -1,0 +1,34 @@
+package com.ethan.voxyworldgenv2.mixin;
+
+import com.ethan.voxyworldgenv2.core.ChunkGenerationManager;
+import com.ethan.voxyworldgenv2.core.Config;
+import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.chunk.ChunkAccess;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ChunkMap.class)
+public abstract class ChunkSaveMixin {
+
+    @Shadow @Final private ServerLevel level;
+
+    @Inject(
+        method = "save",
+        at = @At("HEAD"),
+        cancellable = true
+    )
+    private void onChunkSave(ChunkAccess chunk, CallbackInfoReturnable<Boolean> cir) {
+        if (!Config.DATA.saveNormalChunks) {
+            long chunkPos = chunk.getPos().toLong();
+            if (ChunkGenerationManager.getInstance().isVoxyOnlyChunk(level.dimension(), chunkPos)) {
+                ChunkGenerationManager.getInstance().incrementSaveSkipped();
+                cir.setReturnValue(true);
+            }
+        }
+    }
+}

--- a/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
@@ -1,10 +1,10 @@
 package com.ethan.voxyworldgenv2.mixin;
 
 import com.ethan.voxyworldgenv2.core.Config;
+import com.ethan.voxyworldgenv2.core.ChunkGenerationManager;
 import com.ethan.voxyworldgenv2.core.LodChunkTracker;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import org.spongepowered.asm.mixin.Final;
@@ -17,12 +17,17 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ChunkMap.class)
 public abstract class ChunkSaveMixin {
 
+    // reading a @Final field is safe from any thread — it is set once in the constructor
     @Shadow @Final ServerLevel level;
 
     /**
      * Intercepts chunk saves. When saveNormalChunks is false, chunks that were only
-     * loaded for LOD generation are skipped unless a player is within view distance.
-     * Runs on the main thread — no synchronization concerns with level.players().
+     * loaded for LOD generation are suppressed unless a player is within view distance.
+     *
+     * THREAD SAFETY: ChunkMap.save() is called from C2ME storage threads, not just
+     * the main server thread. This method must not touch any main-thread-only APIs.
+     * All player proximity data is read from ChunkGenerationManager's thread-safe
+     * cached maps (ConcurrentHashMap) which are updated on the main thread each tick.
      */
     @Inject(method = "save", at = @At("HEAD"), cancellable = true)
     private void voxyworldgen$onSave(ChunkAccess chunk, CallbackInfoReturnable<Boolean> cir) {
@@ -33,19 +38,16 @@ public abstract class ChunkSaveMixin {
 
         if (!tracker.isLodOnly(this.level.dimension(), pos.toLong())) return;
 
-        // allow save if any player is within vanilla view distance (+ 2 chunk buffer)
-        int viewDist = this.level.getServer().getPlayerList().getViewDistance() + 2;
-        for (ServerPlayer player : this.level.players()) {
-            ChunkPos pc = player.chunkPosition();
-            if (Math.abs(pc.x - pos.x) <= viewDist && Math.abs(pc.z - pos.z) <= viewDist) {
-                // player is nearby — unmark and save normally so the chunk is persisted
-                tracker.unmark(this.level.dimension(), pos.toLong());
-                return;
-            }
+        // isAnyPlayerNear reads only from ConcurrentHashMaps updated each server tick —
+        // safe to call from C2ME storage threads
+        if (ChunkGenerationManager.getInstance().isAnyPlayerNear(this.level.dimension(), pos)) {
+            // player is nearby: unmark and let the save proceed so the chunk persists normally
+            tracker.unmark(this.level.dimension(), pos.toLong());
+            return;
         }
 
-        // no player nearby — suppress save, report false (nothing was written)
-        tracker.incrementSkipped();
+        // no player nearby — suppress this save and record the chunk (once) in the counter
+        tracker.incrementSkipped(this.level.dimension(), pos.toLong());
         cir.setReturnValue(false);
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
@@ -46,8 +46,10 @@ public abstract class ChunkSaveMixin {
             return;
         }
 
-        // no player nearby — suppress this save and record the chunk (once) in the counter
-        tracker.incrementSkipped(this.level.dimension(), pos.toLong());
-        cir.setReturnValue(false);
+        // no player nearby — clear dirty flag so C2ME also skips writing, then suppress
+        tracker.unmark(this.level.dimension(), pos.toLong());
+        ((com.ethan.voxyworldgenv2.mixin.ChunkAccessUnsavedMixin) chunk).voxyworldgen$setUnsaved(false);
+        // return true = "handled" so Minecraft evicts the chunk instead of retrying forever
+        cir.setReturnValue(true);
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
@@ -49,7 +49,8 @@ public abstract class ChunkSaveMixin {
         // no player nearby — clear dirty flag so C2ME also skips writing, then suppress
         tracker.unmark(this.level.dimension(), pos.toLong());
         ((com.ethan.voxyworldgenv2.mixin.ChunkAccessUnsavedMixin) chunk).voxyworldgen$setUnsaved(false);
-        // return true = "handled" so Minecraft evicts the chunk instead of retrying forever
-        cir.setReturnValue(true);
+        // return false to correctly indicate to ChunkMap that the chunk was not saved to disk.
+        // Calling setUnsaved(false) above already ensures that Minecraft won't keep retrying.
+        cir.setReturnValue(false);
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/mixin/ChunkSaveMixin.java
@@ -1,9 +1,11 @@
 package com.ethan.voxyworldgenv2.mixin;
 
-import com.ethan.voxyworldgenv2.core.ChunkGenerationManager;
 import com.ethan.voxyworldgenv2.core.Config;
+import com.ethan.voxyworldgenv2.core.LodChunkTracker;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.ChunkAccess;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
@@ -15,21 +17,35 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(ChunkMap.class)
 public abstract class ChunkSaveMixin {
 
-    @Shadow @Final private ServerLevel level;
+    @Shadow @Final ServerLevel level;
 
-    @Inject(
-        method = "save",
-        at = @At("HEAD"),
-        cancellable = true
-    )
-    private void onChunkSave(ChunkAccess chunk, CallbackInfoReturnable<Boolean> cir) {
-        if (!Config.DATA.saveNormalChunks) {
-            long chunkPos = chunk.getPos().toLong();
-            ChunkGenerationManager manager = ChunkGenerationManager.getInstance();
-            if (manager.isVoxyOnlyChunk(level.dimension(), chunkPos)) {
-                manager.incrementSaveSkipped();
-                cir.setReturnValue(true);
+    /**
+     * Intercepts chunk saves. When saveNormalChunks is false, chunks that were only
+     * loaded for LOD generation are skipped unless a player is within view distance.
+     * Runs on the main thread — no synchronization concerns with level.players().
+     */
+    @Inject(method = "save", at = @At("HEAD"), cancellable = true)
+    private void voxyworldgen$onSave(ChunkAccess chunk, CallbackInfoReturnable<Boolean> cir) {
+        if (Config.DATA.saveNormalChunks) return;
+
+        ChunkPos pos = chunk.getPos();
+        LodChunkTracker tracker = LodChunkTracker.getInstance();
+
+        if (!tracker.isLodOnly(this.level.dimension(), pos.toLong())) return;
+
+        // allow save if any player is within vanilla view distance (+ 2 chunk buffer)
+        int viewDist = this.level.getServer().getPlayerList().getViewDistance() + 2;
+        for (ServerPlayer player : this.level.players()) {
+            ChunkPos pc = player.chunkPosition();
+            if (Math.abs(pc.x - pos.x) <= viewDist && Math.abs(pc.z - pos.z) <= viewDist) {
+                // player is nearby — unmark and save normally so the chunk is persisted
+                tracker.unmark(this.level.dimension(), pos.toLong());
+                return;
             }
         }
+
+        // no player nearby — suppress save, report false (nothing was written)
+        tracker.incrementSkipped();
+        cir.setReturnValue(false);
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/stats/GenerationStats.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/stats/GenerationStats.java
@@ -7,53 +7,58 @@ public class GenerationStats {
     private final AtomicLong chunksCompleted = new AtomicLong(0);
     private final AtomicLong chunksFailed = new AtomicLong(0);
     private final AtomicLong chunksSkipped = new AtomicLong(0);
-    private final AtomicLong chunksSaveSkipped = new AtomicLong(0);
-    
+
     // rolling average over 10s
     private final long[] rollingHistory = new long[10];
     private int historyIndex = 0;
     private long lastCompletedCount = 0;
-    private long lastTickTime = 0;
+    private long lastTickTime = 0; // 0 is the sentinel meaning "not yet initialized"
 
     public void incrementQueued() { chunksQueued.incrementAndGet(); }
     public void incrementCompleted() { chunksCompleted.incrementAndGet(); }
     public void incrementFailed() { chunksFailed.incrementAndGet(); }
     public void incrementSkipped() { chunksSkipped.incrementAndGet(); }
-    public void incrementSaveSkipped() { chunksSaveSkipped.incrementAndGet(); }
-    
+
     public long getQueued() { return chunksQueued.get(); }
     public long getCompleted() { return chunksCompleted.get(); }
     public long getFailed() { return chunksFailed.get(); }
     public long getSkipped() { return chunksSkipped.get(); }
-    public long getSaveSkipped() { return chunksSaveSkipped.get(); }
-    
-    // update rolling average, call every tick
+
+    // update rolling average; call every tick
     public synchronized void tick() {
         long now = System.currentTimeMillis();
-        // shift history once per second
-            long secondsPassed = (now - lastTickTime) / 1000;
-            if (secondsPassed < 1) return; // should not happen given the if check, but safety
-            
-            long currentTotal = chunksCompleted.get() + chunksSkipped.get();
-            long delta = currentTotal - lastCompletedCount;
-            
-            long perSecond = delta / secondsPassed;
-            long remainder = delta % secondsPassed;
-            
-            // limit updates to history length
-            int updateCount = (int) Math.min(secondsPassed, rollingHistory.length);
-            
-            for (int i = 0; i < updateCount; i++) {
-                // distribute remainder
-                long val = perSecond + (i < remainder ? 1 : 0);
-                rollingHistory[historyIndex] = val;
-                historyIndex = (historyIndex + 1) % rollingHistory.length;
-            }
-            
-            // history buffer will be fully overwritten if secondsPassed >= length
-            
-            lastCompletedCount = currentTotal;
-            lastTickTime += secondsPassed * 1000;
+
+        // first call: initialize the baseline and return without touching history
+        if (lastTickTime == 0) {
+            lastTickTime = now;
+            lastCompletedCount = chunksCompleted.get() + chunksSkipped.get();
+            return;
+        }
+
+        long secondsPassed = (now - lastTickTime) / 1000;
+        if (secondsPassed < 1) return;
+
+        long currentTotal = chunksCompleted.get() + chunksSkipped.get();
+        long delta = currentTotal - lastCompletedCount;
+
+        // limit updates to history length to avoid redundant overwrites
+        int updateCount = (int) Math.min(secondsPassed, rollingHistory.length);
+
+        // divide by updateCount (not secondsPassed) so remainder is bounded by the
+        // number of slots actually being written — prevents under-allocation when
+        // secondsPassed > rollingHistory.length
+        long perSlot = delta / updateCount;
+        long remainder = delta % updateCount;
+
+        for (int i = 0; i < updateCount; i++) {
+            // distribute any remainder across the earliest slots
+            long val = perSlot + (i < remainder ? 1 : 0);
+            rollingHistory[historyIndex] = val;
+            historyIndex = (historyIndex + 1) % rollingHistory.length;
+        }
+
+        lastCompletedCount = currentTotal;
+        lastTickTime += secondsPassed * 1000;
     }
 
     public synchronized double getChunksPerSecond() {
@@ -63,17 +68,17 @@ public class GenerationStats {
         }
         return sum / 10.0;
     }
-    
+
     public void reset() {
         chunksQueued.set(0);
         chunksCompleted.set(0);
         chunksFailed.set(0);
         chunksSkipped.set(0);
-        chunksSaveSkipped.set(0);
         synchronized (this) {
             for (int i = 0; i < rollingHistory.length; i++) rollingHistory[i] = 0;
+            historyIndex = 0;
             lastCompletedCount = 0;
-            lastTickTime = System.currentTimeMillis();
+            lastTickTime = 0; // reset to sentinel so next tick() re-initializes cleanly
         }
     }
 }

--- a/src/main/java/com/ethan/voxyworldgenv2/stats/GenerationStats.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/stats/GenerationStats.java
@@ -7,6 +7,7 @@ public class GenerationStats {
     private final AtomicLong chunksCompleted = new AtomicLong(0);
     private final AtomicLong chunksFailed = new AtomicLong(0);
     private final AtomicLong chunksSkipped = new AtomicLong(0);
+    private final AtomicLong chunksSaveSkipped = new AtomicLong(0);
     
     // rolling average over 10s
     private final long[] rollingHistory = new long[10];
@@ -18,11 +19,13 @@ public class GenerationStats {
     public void incrementCompleted() { chunksCompleted.incrementAndGet(); }
     public void incrementFailed() { chunksFailed.incrementAndGet(); }
     public void incrementSkipped() { chunksSkipped.incrementAndGet(); }
+    public void incrementSaveSkipped() { chunksSaveSkipped.incrementAndGet(); }
     
     public long getQueued() { return chunksQueued.get(); }
     public long getCompleted() { return chunksCompleted.get(); }
     public long getFailed() { return chunksFailed.get(); }
     public long getSkipped() { return chunksSkipped.get(); }
+    public long getSaveSkipped() { return chunksSaveSkipped.get(); }
     
     // update rolling average, call every tick
     public synchronized void tick() {
@@ -66,6 +69,7 @@ public class GenerationStats {
         chunksCompleted.set(0);
         chunksFailed.set(0);
         chunksSkipped.set(0);
+        chunksSaveSkipped.set(0);
         synchronized (this) {
             for (int i = 0; i < rollingHistory.length; i++) rollingHistory[i] = 0;
             lastCompletedCount = 0;

--- a/src/main/resources/assets/voxyworldgenv2/lang/en_us.json
+++ b/src/main/resources/assets/voxyworldgenv2/lang/en_us.json
@@ -13,5 +13,7 @@
     "config.voxyworldgenv2.option.max_queue.tooltip": "Maximum number of chunks to keep in the pending queue.",
     "config.voxyworldgenv2.option.max_active": "Max Parallel Tasks",
     "config.voxyworldgenv2.option.max_active.tooltip": "Maximum number of chunks generating simultaneously.",
+    "config.voxyworldgenv2.option.save_normal_chunks": "Save Normal Chunks",
+    "config.voxyworldgenv2.option.save_normal_chunks.tooltip": "When disabled, chunks generated only for Voxy LOD will not be saved to region files. Player-visited chunks are always saved. Reduces disk usage significantly.",
     "debug.voxyworldgenv2.skipped": "skipped"
 }

--- a/src/main/resources/voxyworldgenv2.mixins.json
+++ b/src/main/resources/voxyworldgenv2.mixins.json
@@ -10,7 +10,8 @@
     "ServerChunkCacheMixin",
     "ServerLevelMixin",
     "BlockUpdateMixin",
-    "ChunkSaveMixin"
+    "ChunkSaveMixin",
+    "ChunkAccessUnsavedMixin"
   ],
   "client": [],
   "injectors": {

--- a/src/main/resources/voxyworldgenv2.mixins.json
+++ b/src/main/resources/voxyworldgenv2.mixins.json
@@ -9,7 +9,8 @@
     "MinecraftServerAccess",
     "ServerChunkCacheMixin",
     "ServerLevelMixin",
-    "BlockUpdateMixin"
+    "BlockUpdateMixin",
+    "ChunkSaveMixin"
   ],
   "client": [],
   "injectors": {


### PR DESCRIPTION
 - Player-visited chunks are always saved (no data loss)
  - Reduces disk usage significantly
- **F3 debug panel** — Shows save-skipped count when feature is enabled
- **ModMenu support** — Toggle the setting from the config screen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mod menu toggle to disable saving normal (non-player-claimed) chunks.
  * Startup now emits diagnostic warnings when that optimization is active.
  * In-game debug displays a real-time "lod suppressed" count.
  * Per-dimension LOD tracking to skip saving chunks generated only for level-of-detail when no player is nearby.
  * Skipped-save statistics integrated into generation stats and reset on shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->