### PR TITLE
fix: use optimistic locking to avoid OOM

### DIFF
--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -203,6 +203,7 @@ public final class ChunkGenerationManager {
                             final List<ChunkPos> finalSyncBatch = new ArrayList<>(syncBatch);
                             final ServerLevel level = ds.level;
                             final UUID playerUUID = player.getUUID();
+                            
                             server.execute(() -> {
                                 ServerPlayer p = server.getPlayerList().getPlayer(playerUUID);
                                 if (p != null) {
@@ -210,6 +211,10 @@ public final class ChunkGenerationManager {
                                         LevelChunk c = level.getChunkSource().getChunk(syncPos.x, syncPos.z, false);
                                         if (c != null) {
                                             com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(p, c);
+                                            synced.add(syncPos.toLong());
+                                        } else {
+                                            // 如果区块其实不在内存里，发送失败，回滚
+                                            synced.remove(syncPos.toLong());
                                         }
                                     }
                                 }
@@ -218,7 +223,10 @@ public final class ChunkGenerationManager {
                         }
                     }
                     
-                    if (workDispatched) continue; 
+                    if (workDispatched) {
+                        Thread.sleep(10); // small delay to prevent overwhelming network/server tasks
+                        continue; 
+                    }
                     
                     Thread.sleep(100);
                     continue;

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -203,7 +203,6 @@ public final class ChunkGenerationManager {
                             final List<ChunkPos> finalSyncBatch = new ArrayList<>(syncBatch);
                             final ServerLevel level = ds.level;
                             final UUID playerUUID = player.getUUID();
-                            
                             server.execute(() -> {
                                 ServerPlayer p = server.getPlayerList().getPlayer(playerUUID);
                                 if (p != null) {
@@ -212,9 +211,6 @@ public final class ChunkGenerationManager {
                                         if (c != null) {
                                             com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(p, c);
                                             synced.add(syncPos.toLong());
-                                        } else {
-                                            // 如果区块其实不在内存里，发送失败，回滚
-                                            synced.remove(syncPos.toLong());
                                         }
                                     }
                                 }

--- a/src/main/java/com/ethan/voxyworldgenv2/network/NetworkHandler.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/network/NetworkHandler.java
@@ -92,6 +92,17 @@ public class NetworkHandler {
         VoxyWorldGenV2.LOGGER.info("voxy networking initialized");
     }
 
+    private static void setSyncedState(ServerPlayer player, ChunkPos pos, boolean isSynced) {
+        var synced = PlayerTracker.getInstance().getSyncedChunks(player.getUUID());
+        if (synced != null) {
+            if (isSynced) {
+                synced.add(pos.toLong());
+            } else {
+                synced.remove(pos.toLong());
+            }
+        }
+    }
+
     public static void broadcastLODData(LevelChunk chunk) {
         ChunkPos pos = chunk.getPos();
         int minY = chunk.getMinSectionY();
@@ -137,30 +148,38 @@ public class NetworkHandler {
         }
         
         if (sections.isEmpty()) return;
-        
+
         LODDataPayload payload = new LODDataPayload(pos, minY, sections);
         
         double maxDistSq = 4096.0 * 4096.0;
         
         for (ServerPlayer player : PlayerTracker.getInstance().getPlayers()) {
-            if (player.level() != chunk.getLevel()) continue;
-            
             double dx = player.getX() - (pos.getMiddleBlockX());
             double dz = player.getZ() - (pos.getMiddleBlockZ());
-            if (dx * dx + dz * dz <= maxDistSq) {
-                ServerPlayNetworking.send(player, payload);
-                
-                // mark as synced for this player
-                var synced = PlayerTracker.getInstance().getSyncedChunks(player.getUUID());
-                if (synced != null) {
-                    synced.add(pos.toLong());
-                }
+            
+            if (player.level() != chunk.getLevel() || (dx * dx + dz * dz > maxDistSq)) {
+                setSyncedState(player, pos, false);
+                continue;
             }
+            
+            ServerPlayNetworking.send(player, payload);
+                
+            // // mark as synced for this player
+            // var synced = PlayerTracker.getInstance().getSyncedChunks(player.getUUID());
+            // if (synced != null) {
+            //     synced.add(pos.toLong());
+            // }
         }
     }
 
     public static void sendLODData(ServerPlayer player, LevelChunk chunk) {
         ChunkPos pos = chunk.getPos();
+        
+        if (player.level() != chunk.getLevel()) {
+            setSyncedState(player, pos, false);
+            return;
+        }
+
         int minY = chunk.getMinSectionY();
         List<LODDataPayload.SectionData> sections = new ArrayList<>();
         
@@ -201,14 +220,14 @@ public class NetworkHandler {
             ));
         }
         
-        if (sections.isEmpty()) return;
+        if (sections.isEmpty()) {
+            setSyncedState(player, pos, false);
+            return;
+        }
         
         ServerPlayNetworking.send(player, new LODDataPayload(pos, minY, sections));
-        
-        var synced = PlayerTracker.getInstance().getSyncedChunks(player.getUUID());
-        if (synced != null) {
-            synced.add(pos.toLong());
-        }
+        // double check, could be deleted.
+        setSyncedState(player, pos, true);
     }
 
     public static void sendHandshake(ServerPlayer player) {

--- a/src/main/java/com/ethan/voxyworldgenv2/network/NetworkHandler.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/network/NetworkHandler.java
@@ -174,12 +174,6 @@ public class NetworkHandler {
 
     public static void sendLODData(ServerPlayer player, LevelChunk chunk) {
         ChunkPos pos = chunk.getPos();
-        
-        if (player.level() != chunk.getLevel()) {
-            setSyncedState(player, pos, false);
-            return;
-        }
-
         int minY = chunk.getMinSectionY();
         List<LODDataPayload.SectionData> sections = new ArrayList<>();
         


### PR DESCRIPTION
May fix #20 #24 #25 #45 #46
The issue descriptions are too vague to determine whether they are caused by this bug. However, it is certain that this bug can indeed result in multiple duplicate packets being sent within the same tick, thereby filling up memory.

### About the bug
Since network packet sending is handled by the main thread, and the `ChunkGenerationManager` thread continuously loops syncing chunks, while marking as synced occurs in the network packet sending callback, this leads to the ChunkGenerationManager repeatedly sending the same chunks that are prepared but not yet sent within the same tick, causing the taskQueue to be excessively written to and eventually resulting in an OOM.

### Solution
This PR uses an optimistic marking strategy: marking a chunk as synced immediately when sending, and unmarking it if sending fails or is cancelled. This prevents re-sending of already-sent packets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chunk synchronization tracking to ensure players receive all necessary updates.
  * Added work pacing to reduce performance spikes during chunk generation cycles.

* **Refactor**
  * Optimized chunk syncing management for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->