### PR TITLE
Fix memory leak and server freeze when chunk generation completes

### DIFF
--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -218,8 +218,6 @@ public final class ChunkGenerationManager {
                         }
                     }
                     
-                    if (workDispatched) continue; 
-                    
                     Thread.sleep(100);
                     continue;
                 }


### PR DESCRIPTION
Fixes infinite loop in worker thread that causes memory leak and eventual server crash when all chunks within radius are generated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted worker loop timing behavior to ensure consistent sleep intervals during background processing operations when no batches are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->