### PR TITLE
Fix config parsing and enforce generation queue limits

### DIFF
--- a/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
@@ -65,6 +65,7 @@ public final class DebugRenderer {
             lineList.add("§7completed: §a" + formatNumber(stats.getCompleted()));
             lineList.add("§7skipped: §f" + formatNumber(stats.getSkipped()));
             lineList.add("§7remaining: §e" + formatNumber(remaining) + " §8(" + eta + ")");
+            lineList.add("§7queue: §b" + manager.getQueueSize() + " §8/ " + com.ethan.voxyworldgenv2.core.Config.DATA.maxQueueSize);
             lineList.add("§7active: §b" + manager.getActiveTaskCount());
             lineList.add("§7rate: §f" + String.format("%.1f", rate) + " c/s");
             lineList.add("§7voxy: " + (VoxyIntegration.isVoxyAvailable() ? "§aenabled" : "§cdisabled"));

--- a/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/client/DebugRenderer.java
@@ -65,7 +65,7 @@ public final class DebugRenderer {
             lineList.add("§7completed: §a" + formatNumber(stats.getCompleted()));
             lineList.add("§7skipped: §f" + formatNumber(stats.getSkipped()));
             lineList.add("§7remaining: §e" + formatNumber(remaining) + " §8(" + eta + ")");
-            lineList.add("§7queue: §b" + manager.getQueueSize() + " §8/ " + com.ethan.voxyworldgenv2.core.Config.DATA.maxQueueSize);
+            lineList.add("§7queue: §b" + manager.getQueueSize() + " §8/ " + manager.getConfiguredMaxQueueSize());
             lineList.add("§7active: §b" + manager.getActiveTaskCount());
             lineList.add("§7rate: §f" + String.format("%.1f", rate) + " c/s");
             lineList.add("§7voxy: " + (VoxyIntegration.isVoxyAvailable() ? "§aenabled" : "§cdisabled"));

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -59,6 +59,7 @@ public final class ChunkGenerationManager {
     
     // global state
     private final AtomicInteger activeTaskCount = new AtomicInteger(0);
+    private final AtomicInteger pendingTicketOpCount = new AtomicInteger(0);
     private final GenerationStats stats = new GenerationStats();
     private final AtomicBoolean running = new AtomicBoolean(false);
     private final AtomicBoolean configReloadScheduled = new AtomicBoolean(false);
@@ -123,6 +124,7 @@ public final class ChunkGenerationManager {
         
         dimensionStates.clear();
         pendingTicketOps.clear();
+        pendingTicketOpCount.set(0);
         server = null;
         stats.reset();
         activeTaskCount.set(0);
@@ -168,6 +170,11 @@ public final class ChunkGenerationManager {
 
                 if (tpsMonitor.isThrottled() || pauseCheck.getAsBoolean()) {
                     Thread.sleep(500);
+                    continue;
+                }
+
+                if (getQueueSize() >= Config.DATA.maxQueueSize) {
+                    Thread.sleep(100);
                     continue;
                 }
                 
@@ -265,6 +272,10 @@ public final class ChunkGenerationManager {
                 int processedCount = 0;
                 for (ChunkPos pos : preFiltered) {
                     if (!workerRunning.get()) break;
+
+                    if (getQueueSize() >= Config.DATA.maxQueueSize) {
+                        break;
+                    }
                     
                     boolean acquired = false;
                     try {
@@ -493,6 +504,7 @@ public final class ChunkGenerationManager {
         TicketOp op;
         java.util.Set<ServerLevel> modifiedLevels = new java.util.HashSet<>();
         while ((op = pendingTicketOps.poll()) != null) {
+            pendingTicketOpCount.updateAndGet(v -> Math.max(0, v - 1));
             ServerChunkCache cache = op.level().getChunkSource();
             if (op.add()) {
                 cache.addTicketWithRadius(TicketType.FORCED, op.pos(), 0);
@@ -508,10 +520,12 @@ public final class ChunkGenerationManager {
     
     private void queueTicketAdd(ServerLevel level, ChunkPos pos) {
         pendingTicketOps.add(new TicketOp(level, pos, true));
+        pendingTicketOpCount.incrementAndGet();
     }
     
     private void queueTicketRemove(ServerLevel level, ChunkPos pos) {
         pendingTicketOps.add(new TicketOp(level, pos, false));
+        pendingTicketOpCount.incrementAndGet();
     }
     
     private void cleanupTask(ServerLevel level, ChunkPos pos) {
@@ -573,7 +587,7 @@ public final class ChunkGenerationManager {
         return state != null ? state.remainingInRadius.get() : 0; 
     }
     public boolean isThrottled() { return tpsMonitor.isThrottled(); }
-    public int getQueueSize() { return 0; }
+    public int getQueueSize() { return activeTaskCount.get() + pendingTicketOpCount.get(); }
     
     public void setPauseCheck(java.util.function.BooleanSupplier check) {
         this.pauseCheck = check;

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -173,7 +173,7 @@ public final class ChunkGenerationManager {
                     continue;
                 }
 
-                if (getQueueSize() >= Config.DATA.maxQueueSize) {
+                if (getQueueSize() >= getConfiguredMaxQueueSize()) {
                     Thread.sleep(100);
                     continue;
                 }
@@ -273,7 +273,7 @@ public final class ChunkGenerationManager {
                 for (ChunkPos pos : preFiltered) {
                     if (!workerRunning.get()) break;
 
-                    if (getQueueSize() >= Config.DATA.maxQueueSize) {
+                    if (getQueueSize() >= getConfiguredMaxQueueSize()) {
                         break;
                     }
                     
@@ -588,6 +588,7 @@ public final class ChunkGenerationManager {
     }
     public boolean isThrottled() { return tpsMonitor.isThrottled(); }
     public int getQueueSize() { return activeTaskCount.get() + pendingTicketOpCount.get(); }
+    public int getConfiguredMaxQueueSize() { return Math.max(1, Config.DATA.maxQueueSize); }
     
     public void setPauseCheck(java.util.function.BooleanSupplier check) {
         this.pauseCheck = check;

--- a/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
@@ -15,7 +15,7 @@ public final class Config {
     private static final Path CONFIG_PATH = FabricLoader.getInstance().getConfigDir().resolve("voxyworldgenv2.json");
     private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
     
-    public static ConfigData DATA = new ConfigData();
+    public static volatile ConfigData DATA = new ConfigData();
     
     public static void load() {
         if (!Files.exists(CONFIG_PATH)) {

--- a/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
@@ -31,9 +31,15 @@ public final class Config {
         }
         
         try (var reader = Files.newBufferedReader(CONFIG_PATH)) {
-            DATA = GSON.fromJson(reader, ConfigData.class);
-        } catch (IOException e) {
-            VoxyWorldGenV2.LOGGER.error("failed to load config", e);
+            ConfigData loaded = GSON.fromJson(reader, ConfigData.class);
+            if (loaded == null) {
+                throw new IOException("config file was empty or invalid");
+            }
+            DATA = loaded;
+        } catch (Exception e) {
+            VoxyWorldGenV2.LOGGER.error("failed to load config, restoring defaults", e);
+            DATA = new ConfigData();
+            save();
         }
     }
     

--- a/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/Config.java
@@ -3,6 +3,7 @@ package com.ethan.voxyworldgenv2.core;
 import com.ethan.voxyworldgenv2.VoxyWorldGenV2;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonParseException;
 import net.fabricmc.loader.api.FabricLoader;
 
 import java.io.IOException;
@@ -33,14 +34,31 @@ public final class Config {
         try (var reader = Files.newBufferedReader(CONFIG_PATH)) {
             ConfigData loaded = GSON.fromJson(reader, ConfigData.class);
             if (loaded == null) {
-                throw new IOException("config file was empty or invalid");
+                restoreDefaultsAndSave("config file was empty, restoring defaults", null);
+                return;
             }
+            loaded.normalize();
             DATA = loaded;
+        } catch (JsonParseException | IllegalStateException e) {
+            restoreDefaultsAndSave("failed to parse config, restoring defaults", e);
+        } catch (IOException e) {
+            // Keep the current in-memory config on pure I/O failures.
+            VoxyWorldGenV2.LOGGER.error("failed to load config (io error), keeping current config", e);
         } catch (Exception e) {
-            VoxyWorldGenV2.LOGGER.error("failed to load config, restoring defaults", e);
-            DATA = new ConfigData();
-            save();
+            restoreDefaultsAndSave("failed to load config, restoring defaults", e);
         }
+    }
+
+    private static void restoreDefaultsAndSave(String message, Throwable error) {
+        if (error != null) {
+            VoxyWorldGenV2.LOGGER.error(message, error);
+        } else {
+            VoxyWorldGenV2.LOGGER.warn(message);
+        }
+        ConfigData defaults = new ConfigData();
+        defaults.normalize();
+        DATA = defaults;
+        save();
     }
     
     public static void save() {
@@ -61,5 +79,12 @@ public final class Config {
         public int update_interval = 20; // legacy field for Compat
         public int maxQueueSize = 20000;
         public int maxActiveTasks = 20;
+
+        public void normalize() {
+            maxQueueSize = Math.max(1, maxQueueSize);
+            maxActiveTasks = Math.max(1, maxActiveTasks);
+            generationRadius = Math.max(1, generationRadius);
+            update_interval = Math.max(1, update_interval);
+        }
     }
 }


### PR DESCRIPTION
**Changes**

* Config loading now handles invalid or empty JSON. If parsing fails, defaults are restored and a valid config is written.
* Generation queue now reports its real size (no longer returns `0`).
* `maxQueueSize` is enforced in the worker loop, preventing new tasks when the limit is reached.
* Debug HUD displays the current queue size for visibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration loading with better error handling, default restoration, and value normalization/sanitization

* **Performance & Stability**
  * Added queue-size tracking and throttling to prevent overload
  * Worker loop now backs off/pauses when queue reaches configured maximum

* **Debug Features**
  * Debug overlay now shows current generation queue size and configured maximum limits
<!-- end of auto-generated comment: release notes by coderabbit.ai -->