### PR TITLE
Sync unloaded chunks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ replay_pid*
 build/
 .gradle/
 run/
+bin
 
 # IDE
 .idea/

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -7,14 +7,19 @@ import com.ethan.voxyworldgenv2.mixin.MinecraftServerAccess;
 
 import com.ethan.voxyworldgenv2.mixin.ServerChunkCacheMixin;
 import com.ethan.voxyworldgenv2.stats.GenerationStats;
+
+import net.minecraft.client.multiplayer.chat.LoggedChatMessage.Player;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ChunkResult;
 import net.minecraft.server.level.ServerChunkCache;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.level.Ticket;
 import net.minecraft.server.level.TicketType;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import net.minecraft.world.level.chunk.ChunkAccess;
 import net.minecraft.world.level.chunk.LevelChunk;
 import net.minecraft.world.level.chunk.status.ChunkStatus;
 
@@ -33,6 +38,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -194,6 +200,15 @@ public final class ChunkGenerationManager {
                 if (batch == null) {
                     // if no generation work, try to catch up on syncing for any player
                     boolean workDispatched = false;
+
+                    ArrayList<UUID> unsyncedPlayersUUIDs = new ArrayList<>();
+
+                    for (ServerPlayer player : players) {
+                        if (PlayerTracker.getInstance().getSyncedChunks(player.getUUID()) == null) {
+                            unsyncedPlayersUUIDs.add(player.getUUID());
+                        }
+                    }
+                    
                     for (ServerPlayer player : players) {
                         var synced = PlayerTracker.getInstance().getSyncedChunks(player.getUUID());
                         if (synced == null) continue;
@@ -207,26 +222,49 @@ public final class ChunkGenerationManager {
                             workDispatched = true;
                             final List<ChunkPos> finalSyncBatch = new ArrayList<>(syncBatch);
                             final ServerLevel level = ds.level;
+
                             final UUID playerUUID = player.getUUID();
                             // mark all as synced now so we don't retry unloaded chunks in a tight loop;
                             // the block update mixin will re-sync them when they load naturally
                             for (ChunkPos syncPos : finalSyncBatch) {
                                 synced.add(syncPos.toLong());
                             }
+                            
                             server.execute(() -> {
                                 ServerPlayer p = server.getPlayerList().getPlayer(playerUUID);
                                 if (p != null) {
                                     for (ChunkPos syncPos : finalSyncBatch) {
-                                        LevelChunk c = level.getChunkSource().getChunk(syncPos.x, syncPos.z, false);
-                                        if (c != null) {
-                                            com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(p, c);
-                                        }
+                                        LevelChunk chunk = level.getChunkSource().getChunk(syncPos.x, syncPos.z, false);
+                                        
                                         // if c == null the chunk is not loaded; the BlockUpdateMixin will
                                         // handle syncing it when it gets loaded into memory later
+                                        if (chunk != null) {
+
+                                            // Find other players that needs this chunk
+                                            ArrayList<ServerPlayer> playersToSendTo = new ArrayList<>();
+                                            for (UUID otherPlayerUUID : unsyncedPlayersUUIDs) {
+                                                ServerPlayer otherPlayer = server.getPlayerList().getPlayer(otherPlayerUUID);
+                                                if (otherPlayer != null) {
+                                                    if (PlayerTracker.getInstance().getSyncedChunks(otherPlayer.getUUID()).contains(syncPos.toLong()) == false) {
+                                                        playersToSendTo.add(otherPlayer);
+
+                                                        // add to player's synced chunks
+                                                        PlayerTracker.getInstance().getSyncedChunks(otherPlayer.getUUID()).add(syncPos.toLong());
+                                                    }
+                                                }
+                                            }
+                                            
+                                            for (ServerPlayer playerToSendTo : playersToSendTo) {
+                                                com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(playerToSendTo, chunk);
+                                            }
+
+                                            
+                                        }
                                     }
                                 }
                             });
-                            break; // processed one player, break to skip sleep
+                            
+                            //break; // processed one player, break to skip sleep
                         }
                     }
                     

--- a/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -216,7 +216,7 @@ public final class ChunkGenerationManager {
                         DimensionState ds = getOrSetupState((ServerLevel) player.level());
                         int radius = ds.tellusActive ? Math.max(Config.DATA.generationRadius, 128) : Config.DATA.generationRadius;
                         List<ChunkPos> syncBatch = new ArrayList<>();
-                        ds.distanceGraph.collectCompletedInRange(player.chunkPosition(), radius, synced, syncBatch, 64);
+                        ds.distanceGraph.collectCompletedInRange(player.chunkPosition(), radius, synced, syncBatch, 32);
                         
                         if (!syncBatch.isEmpty()) {
                             workDispatched = true;
@@ -234,38 +234,48 @@ public final class ChunkGenerationManager {
                                 ServerPlayer p = server.getPlayerList().getPlayer(playerUUID);
                                 if (p != null) {
                                     for (ChunkPos syncPos : finalSyncBatch) {
-                                        LevelChunk chunk = level.getChunkSource().getChunk(syncPos.x, syncPos.z, false);
+                                        // loadOrGenerate is set to true, however chunks will not be generated, only loaded, because syncBatch only contains previously generated chunks
                                         
-                                        // if c == null the chunk is not loaded; the BlockUpdateMixin will
-                                        // handle syncing it when it gets loaded into memory later
-                                        if (chunk != null) {
+                                        var chunkFuture = level.getChunkSource().getChunkFuture(syncPos.x, syncPos.z, ChunkStatus.FULL, true);
+                                        
+                                        chunkFuture.whenCompleteAsync((result, throwable) -> {
+                                            if (throwable == null && result != null && result.isSuccess() && result.orElse(null) instanceof LevelChunk chunk) {
+                                                if (chunk != null) {
 
-                                            // Find other players that needs this chunk
-                                            ArrayList<ServerPlayer> playersToSendTo = new ArrayList<>();
-                                            for (UUID otherPlayerUUID : unsyncedPlayersUUIDs) {
-                                                ServerPlayer otherPlayer = server.getPlayerList().getPlayer(otherPlayerUUID);
-                                                if (otherPlayer != null) {
-                                                    if (PlayerTracker.getInstance().getSyncedChunks(otherPlayer.getUUID()).contains(syncPos.toLong()) == false) {
-                                                        playersToSendTo.add(otherPlayer);
+                                                    // Find other players that need this chunk to avoid loading the same chunk from disk multiple times.
+                                                    ArrayList<ServerPlayer> playersToSendTo = new ArrayList<>();
+                                                    for (UUID otherPlayerUUID : unsyncedPlayersUUIDs) {
+                                                        ServerPlayer otherPlayer = server.getPlayerList().getPlayer(otherPlayerUUID);
+                                                        if (otherPlayer != null) {
+                                                            if (PlayerTracker.getInstance().getSyncedChunks(otherPlayer.getUUID()).contains(syncPos.toLong()) == false) {
+                                                                playersToSendTo.add(otherPlayer);
 
-                                                        // add to player's synced chunks
-                                                        PlayerTracker.getInstance().getSyncedChunks(otherPlayer.getUUID()).add(syncPos.toLong());
+                                                                // add to player's synced chunks
+                                                                PlayerTracker.getInstance().getSyncedChunks(otherPlayer.getUUID()).add(syncPos.toLong());
+                                                            }
+                                                        }
+                                                    }
+                                                    
+                                                    for (ServerPlayer playerToSendTo : playersToSendTo) {
+                                                        com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(playerToSendTo, chunk);
                                                     }
                                                 }
+                                            } else {
+                                                VoxyWorldGenV2.LOGGER.error("failed to load chunk", throwable);
                                             }
-                                            
-                                            for (ServerPlayer playerToSendTo : playersToSendTo) {
-                                                com.ethan.voxyworldgenv2.network.NetworkHandler.sendLODData(playerToSendTo, chunk);
-                                            }
-
-                                            
-                                        }
+                                        });
                                     }
                                 }
+
+                                // This will unload the chunks from the chunck cache after they've been sent, to avoid keeping chunks in memory that are out of the server's view distance
+                                ((ServerChunkCacheMixin) level.getChunkSource()).invokeRunDistanceManagerUpdates();
                             });
                             
                             //break; // processed one player, break to skip sleep
                         }
+                        // Syncing is very disk heavy, so a delay is here to prevent overwhelming the server.
+                        // TODO: add a config option to set a maximum chunks per second sent, so that sync speed is user defined and can be adjusted based on hardware.
+                        Thread.sleep(100);
                     }
                     
                     if (workDispatched) {

--- a/src/main/java/com/ethan/voxyworldgenv2/network/NetworkState.java
+++ b/src/main/java/com/ethan/voxyworldgenv2/network/NetworkState.java
@@ -2,6 +2,28 @@ package com.ethan.voxyworldgenv2.network;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import net.fabricmc.fabric.api.resource.v1.reloader.ResourceReloaderKeys.Client;
+import net.fabricmc.loader.api.FabricLoader;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+
+
+import org.apache.logging.log4j.Level;
+
+import com.ethan.voxyworldgenv2.VoxyWorldGenV2;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.Files;
+import java.io.File;
+
+import java.io.BufferedOutputStream;
+
 public class NetworkState {
     private static boolean serverConnected = false;
     private static final AtomicLong chunksReceived = new AtomicLong(0);
@@ -14,9 +36,74 @@ public class NetworkState {
     private static long lastChunkCount = 0;
     private static long lastByteCount = 0;
 
+    public static void save() {
+        Path savePath = savePath();
+        VoxyWorldGenV2.LOGGER.info("trying to save network state to path: " + savePath);
+
+        File clientDirectory = new File(FabricLoader.getInstance().getGameDir().resolve(".voxyworldgen").toUri());
+        VoxyWorldGenV2.LOGGER.info("does client directory exist: " + clientDirectory.exists());
+        VoxyWorldGenV2.LOGGER.info("client directory: " + clientDirectory.toString());
+        if (!clientDirectory.exists()) {
+            VoxyWorldGenV2.LOGGER.info("Voxy world gen client directory does not exist, attempting to create it: " + clientDirectory);
+            try {
+                if (!clientDirectory.mkdir()) {
+                    VoxyWorldGenV2.LOGGER.error("could not create client directory");
+                }
+            } catch (Exception e) {
+                VoxyWorldGenV2.LOGGER.error("could not create client directory bad", e);
+            }
+        }
+
+        File stateFile = new File(savePath.toUri());
+        if (!stateFile.exists()) {
+            try {
+                if (!stateFile.createNewFile()) {
+                    VoxyWorldGenV2.LOGGER.error("could not create network state file");
+                }
+            } catch (Exception e) {
+                VoxyWorldGenV2.LOGGER.error("could not create network state file", e);
+            }
+        }
+
+        try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(savePath, StandardOpenOption.CREATE)))) {
+            out.writeLong(chunksReceived.get());
+        } catch (Exception e) {
+            VoxyWorldGenV2.LOGGER.error("failed to save network state", e);
+        }
+    }
+
+    public static void load() {
+        Path savePath = savePath();
+        VoxyWorldGenV2.LOGGER.info("trying to load network state from path: " + savePath);
+
+        try (DataInputStream in = new DataInputStream(new BufferedInputStream(Files.newInputStream(savePath)))) {
+            Long toSetChunks = in.readLong();
+            chunksReceived.set(toSetChunks);
+            Long hello = chunksReceived.get();
+            VoxyWorldGenV2.LOGGER.info("tried to set Chunks recieved to: " + toSetChunks.toString() + " it is now set to: " + hello.toString());
+        } catch (Exception e) {
+            VoxyWorldGenV2.LOGGER.error("failed to load network state", e);
+        }
+    }
+
+    private static Path savePath() {
+        String worldName = null;
+        if (Minecraft.getInstance().getSingleplayerServer() != null) {
+            worldName = Minecraft.getInstance().getSingleplayerServer().name();
+        } else {
+            worldName = Minecraft.getInstance().getCurrentServer().ip;
+        }
+
+        return FabricLoader.getInstance().getGameDir().resolve(".voxyworldgen/" + worldName + ".bin");
+    }
+
+
     public static void setServerConnected(boolean connected) {
+        VoxyWorldGenV2.LOGGER.info("setting server connected state to: " + connected);
+
         serverConnected = connected;
         if (!connected) {
+            save();
             chunksReceived.set(0);
             bytesReceived.set(0);
             receiveRate = 0;
@@ -24,6 +111,8 @@ public class NetworkState {
             lastUpdateTime = 0;
             lastChunkCount = 0;
             lastByteCount = 0;
+        } else if (connected) {
+            load();
         }
     }
 


### PR DESCRIPTION
Currently, chunks are only synced to clients if that chunk is loaded in the server's chunk cache in memory. This is a problem because distant chunks are ditched from memory right after being generated. If a client joins the server after voxy world gen is finished generating chunks, those chunks will never be in memory until the player goes to those chunks, which defeats the purpose of the mod. There are two solutions to this:

 *   Keep distant chunks in memory
 *   Load distant chunks from disk as needed

Obviously the first option would use way too much memory, so in this fork, chunks are loaded from disk when a client needs to sync them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic persistence for world generation progress, saving and restoring state between game sessions.

* **Improvements**
  * Optimized chunk synchronization to process multiple players concurrently using asynchronous chunk loading for improved efficiency.

* **Chores**
  * Updated build artifact ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->