### PR TITLE
Fix worker spinning forever on shutdown, hanging the 'Saving world' screen

### DIFF
--- a/common/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/common/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -321,8 +321,10 @@ public final class ChunkGenerationManager {
         java.util.Arrays.fill(remainingSlice, perPlayerCap);
         int activePlayers = n;
 
-        // cycle until budget spent or nobody has work
-        while (dispatched < budget && activePlayers > 0) {
+        // cycle until budget spent or nobody has work. also bail on shutdown,
+        // otherwise this spins forever once dispatchBatch stops sending
+        while (dispatched < budget && activePlayers > 0
+                && workerRunning.get() && !Thread.currentThread().isInterrupted()) {
             for (int i = 0; i < n && dispatched < budget; i++) {
                 if (exhausted[i] || remainingSlice[i] <= 0) continue;
 

--- a/common/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/common/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -325,6 +325,7 @@ public final class ChunkGenerationManager {
         // otherwise this spins forever once dispatchBatch stops sending
         while (dispatched < budget && activePlayers > 0
                 && workerRunning.get() && !Thread.currentThread().isInterrupted()) {
+            int dispatchedBeforePass = dispatched;
             for (int i = 0; i < n && dispatched < budget; i++) {
                 if (exhausted[i] || remainingSlice[i] <= 0) continue;
 
@@ -349,6 +350,7 @@ public final class ChunkGenerationManager {
                     activePlayers--;
                 }
             }
+            if (dispatched == dispatchedBeforePass) break; // break loop if last pass did nothing
         }
         return dispatched > 0;
     }


### PR DESCRIPTION
**Bug:** exiting a world can hang forever on the "Saving world" screen, with `Voxy-WorldGen-Worker` at 100% CPU. Seen on 2.4.2 NeoForge/1.21.1, same code on `unified`.

**Cause:**
1. `stopWorker()` sets `workerRunning = false`
2. `dispatchBatch` now returns 0 without consuming work
3. `dispatchGeneration`'s loop only exits when the budget is spent or all players are out of work. With `sent = 0` neither ever happens, so it loops forever
4. the worker outlives the 5s join in `stopWorker()` and keeps queueing chunk work, so `stopServer()`'s `hasWork()` wait never finishes

Log from a hung session (5s gap = join timeout, then the supposedly-stopped worker re-inits tellus):

```
21:01:44.473 [Server thread]          server stopping, shutting down manager
21:01:49.473 [Server thread]          tellus integration shutdown
21:01:49.482 [Voxy-WorldGen-Worker]   tellus integration hub initialized (12 workers)
21:01:49.491 [Server thread]          Saving worlds   <- stuck here for hours
```

**Fix:** check `workerRunning` and the interrupt flag in the loop condition. Tested in a ~320-mod pack, world exit is clean again.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chunk generation shutdown behavior.
  * Generation dispatch now stops promptly when workers shut down or processing is interrupted.
  * Prevented potential indefinite processing when no additional work can be dispatched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->