### PR TITLE
Fix out of memory crash when pausing game

### DIFF
--- a/common/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
+++ b/common/src/main/java/com/ethan/voxyworldgenv2/core/ChunkGenerationManager.java
@@ -121,7 +121,7 @@ public final class ChunkGenerationManager {
         sessionId.incrementAndGet();
         this.server = server;
         this.running.set(true);
-        this.pauseCheck = () -> false;
+        //this.pauseCheck = () -> false;
         Config.load();
         this.throttle = new Semaphore(Config.DATA.maxActiveTasks);
         startWorker();


### PR DESCRIPTION
Fixes #91
---
`ChunkGenerationManager.initialize()` resets `pauseCheck` back to its default:

```java
public void initialize(MinecraftServer server) {
    sessionId.incrementAndGet();
    this.server = server;
    this.running.set(true);
    this.pauseCheck = () -> false;   // <-- overwrites the client's registration
    Config.load();
    this.throttle = new Semaphore(Config.DATA.maxActiveTasks);
    startWorker();
    ...
}
```

Even though that `pauseCheck` is already set to the default value of false when creating the class. And since this initialization function is run after `onInitializeClient` from the class `VoxyWorldGenV2Client`, `setPauseCheck` is ignored. You can verify this yourself in any log from the game: the mod's `initializing voxy world gen v2 client line` (from the client entry point) appears near the top of the log during startup, while `server started, initializing manager appears later`, each time you load a world.

This fix was verified on 26.2 using both Fabric and NeoForge. The worker stops dispatching new generation tasks while the pause menu is open after this change, and the heap stays stable over a long paused session that previously would OOM.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the existing pause-check behavior when initializing chunk generation, preventing previously configured pause controls from being unintentionally reset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->